### PR TITLE
Compatibility fix for cython language level 3

### DIFF
--- a/PARIKernel/kernel.pyx
+++ b/PARIKernel/kernel.pyx
@@ -147,7 +147,7 @@ class PARIKernel(Kernel):
                 if store_history:
                     pari_add_hist(result, t_ms)
 
-                if last != ';' and not silent:
+                if last != c';' and not silent:
                     content = {
                         'execution_count': pari_nb_hist(),
                         'data': {


### PR DESCRIPTION
The missing character prefix is an error with cython language level 3.  It is possible to build with language level 3 with just this change.
